### PR TITLE
Speedup pip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.egg-info
+*.pyc
+*.pyo
+*.DS_Store
+build/*

--- a/collective/eggproxy/config.py
+++ b/collective/eggproxy/config.py
@@ -40,6 +40,7 @@ config.set("eggproxy", "listen", '127.0.0.1')
 config.set("eggproxy", "port", '8888')
 config.set("eggproxy", "always_refresh", '0')
 config.set("eggproxy", "timeout", '3')
+config.set("eggproxy", "ignored_extensions", '')
 
 if os.path.exists(CONFIG_FILE):
     config.readfp(open(CONFIG_FILE))

--- a/collective/eggproxy/tests/test_utils.py
+++ b/collective/eggproxy/tests/test_utils.py
@@ -44,3 +44,15 @@ def test_package_case_sensitive():
 
     page = open(os.path.join(dirname, 'index.html')).read()
     assert '<html><head><title>Paste</title></head>' in page
+
+@with_setup(setup_func, teardown_func)
+def test_ignored_extensions():
+    filename = os.path.join(tempdir, 'Paste', 'index.html')
+    # Not filtering
+    index.ignored_extensions = []
+    index.updatePackageIndex('Paste', tempdir)
+    assert '.egg' in open(filename).read()
+    # Filtering
+    index.ignored_extensions = ['.egg']
+    index.updatePackageIndex('Paste', tempdir)
+    assert '.egg' not in open(filename).read()


### PR DESCRIPTION
I've added configurable support for ignoring extensions (e.g. .egg and .exe) from dist index pages to allow for faster installations when pip will be the only eggproxy client.  A test is included to verify that the filtered behaviour is as intended, and that unfiltered behaviour remains unmodified. 
